### PR TITLE
fix: Properly scale images and respect cache behavior

### DIFF
--- a/src/handlers/image.rs
+++ b/src/handlers/image.rs
@@ -126,9 +126,11 @@ fn image_handler_helper(
 
     // Construct HTTP Body
     // If requested image is found in cache, the cached version is returned
-    let body = match check_cache(uuid, height, width, quality) {
-        true => read(get_cache_entry(&uuid.to_string(), height, width, quality)).unwrap(),
-        false => match manipulate_image(path, height, width, quality, cache_behavior) {
+    let body = match cache_behavior {
+        CacheBehavior::Normal if check_cache(uuid, height, width, quality) => {
+            read(get_cache_entry(&uuid.to_string(), height, width, quality)).unwrap()
+        }
+        _ => match manipulate_image(path, image_query.height, width, quality, cache_behavior) {
             Err(err) => {
                 log::error!("{}", err);
                 return Err((


### PR DESCRIPTION
Fixes two issues:
- When an image was found in the cache, it did not matter whether CacheBehavior was set to Skip or not, it would get used anyway
- When scaling images, the height was always provided as a ThumbnailOption even if it was not required. This lead to VIPS keeping that height and not performing any scaling.


NOTE: The same issue is still present for the height parameter, e.g. try to fetch any image with ?height=XYZ. It has no scaling applied to it. However, I do not see a way to fix this with the libvips bindings.

Previously, images were not scaled but cut, i.e. some parts were cut off instead of the whole image being present in the result.