### PR TITLE
fix: Don't forcefully download images

### DIFF
--- a/src/handlers/image.rs
+++ b/src/handlers/image.rs
@@ -114,7 +114,7 @@ fn image_handler_helper(
         (header::CONTENT_TYPE, "image/webp".to_owned()),
         (
             header::CONTENT_DISPOSITION,
-            format!("attachment; filename={:?}.webp", uuid),
+            format!("inline; filename={:?}.webp", uuid),
         ),
     ];
 


### PR DESCRIPTION
Don't know why attachment was used in the first place, but it was the wrong decision.